### PR TITLE
point the badges at the right repository and fix the multi-namespace example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # nestjs-kysely
 
 [![npm version](https://badge.fury.io/js/nestjs-kysely.svg)](https://badge.fury.io/js/nestjs-kysely.svg)
-[![check](https://github.com/kzmat/nestjs-kysely/actions/workflows/check.yml/badge.svg)](https://github.com/kzmat/nestjs-kysely/actions/workflows/check.yml)
-[![codecov](https://codecov.io/gh/kzmat/nestjs-kysely/branch/master/graph/badge.svg?token=5PN87HH33L)](https://codecov.io/gh/kzmat/nestjs-kysely)
+[![check](https://github.com/kazu728/nestjs-kysely/actions/workflows/check.yml/badge.svg)](https://github.com/kazu728/nestjs-kysely/actions/workflows/check.yml)
+[![codecov](https://codecov.io/gh/kazu728/nestjs-kysely/branch/master/graph/badge.svg?token=5PN87HH33L)](https://codecov.io/gh/kazu728/nestjs-kysely)
 
 `nestjs-kysely` implements a module that provides the client of Kysely, which is
 a type-safe query builder.
@@ -170,13 +170,13 @@ import { DB } from "./@types";
 @Controller()
 export class AppController {
   constructor(
-    @InjectKysely("mysql") private readonly mysql: Kysely<unknown>,
-    @InjectKysely("sqlite") private readonly sqlite: Kysely<unknown>,
+    @InjectKysely("mysql") private readonly mysql: Kysely<DB>,
+    @InjectKysely("sqlite") private readonly sqlite: Kysely<DB>,
   ) {}
 
   @Get()
   async getHello(): Promise<string> {
-    const result = await this.db
+    const result = await this.mysql
       .selectFrom("person")
       .innerJoin("pet", "pet.owner_id", "person.id")
       .selectAll()


### PR DESCRIPTION
## Summary

Two fixes to the README.

- The check and codecov badges pointed at `kzmat/nestjs-kysely`, which does not
  exist. Point them at `kazu728/nestjs-kysely`, matching `package.json` and the
  remote.
- The multiple-namespace example took `mysql` and `sqlite` in the constructor
  but queried `this.db`. Use `this.mysql`, and type both as `Kysely<DB>` since
  `Kysely<unknown>` makes `selectFrom("person")` a type error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)